### PR TITLE
fix: filter unexpected parameters from content type string

### DIFF
--- a/radiorecorder/src/main/java/de/sfuhrm/radiorecorder/metadata/MimeType.java
+++ b/radiorecorder/src/main/java/de/sfuhrm/radiorecorder/metadata/MimeType.java
@@ -73,8 +73,10 @@ public enum MimeType {
     }
 
     boolean matches(String contentTypeToMatch) {
+        /* Retrieve only 'type/subtype', filtering out any additional parameters */
+        String typeSTypeToMatch = contentTypeToMatch.split(";", 2)[0];
         for (String contentType : contentTypes) {
-            if (contentTypeToMatch.equalsIgnoreCase(contentType)) {
+            if (typeSTypeToMatch.equalsIgnoreCase(contentType)) {
                 return true;
             }
         }


### PR DESCRIPTION
Some webradio servers return additional parameters to the content type string (for example "audio/aac; charset=UTF-8"). In this case the program refused to continue as it does not match any of the MimeType defined.

With this fix, parameters are discarded and only the type/subtype is checked.